### PR TITLE
Fix npm3 error and update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ function optimizer() {
 		 * @return {Stream}
 		 */
 		optimize: function(options) {
-			var imageOptim = 'sh ./node_modules/gulp-imageoptim/node_modules/.bin/imageOptim -a -c -q';
+			var imageOptimPath = require.resolve('imageoptim-cli');
+			var imageOptim = 'sh ' + imageOptimPath + ' -a -c -q';
 			var curConfig = _.clone(config);
 
 			// Set config optiosn to use for this current optimization session
@@ -69,7 +70,7 @@ function optimizer() {
 
 				exec('find ' + file.optimizedImagePath + ' | ' + imageOptim + ' | grep TOTAL ', function(error, stdout) {
 					var status = '';
-					
+
 					if (error === null) {
 						var savings = parseInt(stdout.replace(/.*\(([0-9]+)(\.[0-9]+)?\%\)/, '$1'));
 
@@ -101,6 +102,6 @@ function optimizer() {
 
 
 /**
- * Export 
+ * Export
  */
 module.exports 	= optimizer();

--- a/package.json
+++ b/package.json
@@ -35,15 +35,15 @@
     "compression"
   ],
   "devDependencies": {
-    "chai": "^2.2.0",
+    "chai": "^3.3.0",
     "mocha": "^2.2.4",
     "mocha-jshint": "^2.1.1"
   },
   "dependencies": {
     "blueimp-md5": "^1.1.0",
-    "chalk": "~1.0.0",
+    "chalk": "~1.1.1",
     "imageoptim-cli": "^1.11.6",
-    "lodash": "~3.7.0",
-    "through2": "^0.6.5"
+    "lodash": "~3.10.1",
+    "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
Hi,

gulp-imageoptim doesn't work well when installed via npm v3.You'll get the following error:
/node_modules/gulp-imageoptim/node_modules/.bin/imageOptim: No such file or directory

I fixed this problem and updated all dependencies.
